### PR TITLE
Dynamic identification of drive names

### DIFF
--- a/docs/homelab/qnap-disk-spindown.md
+++ b/docs/homelab/qnap-disk-spindown.md
@@ -41,7 +41,7 @@ md9 : active raid1 sdd[3] sdb[2] sda[1] nvme0n1p4[0]
 
 Since I've installed an NVMe drive, I only want to retain that drive for my QTS storage. Remember the other drives, because you will need to edit the scripts below to fit your storage solution.
 
-### Identifying which drives
+### Consistent idenfitication of drive names
 As drive letters may change during reboots (e.g., sda can become sdb in some cases) it's good to positively identify the different devices in some way. Parted can help with this:
 
 ```sudo parted -lms 2>/dev/null | grep "/dev/sd"```


### PR DESCRIPTION
Hi Alex, thanks for the clear writeup! In my case the QNAP switched around the SSD and one of the HDDs on me... This addition prevents that from happening. 
I've also decided to use the full script you linked to as that is a little more robust with checking if the RAID is being rebuilt etc., but your script definitely put me on the right path, thanks!